### PR TITLE
Fixed bug in the clearAnnotations() method

### DIFF
--- a/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
+++ b/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
@@ -365,7 +365,7 @@ public class AceEditor extends Composite implements RequiresResize {
 	public native void clearAnnotations() /*-{
 		var editor = this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::editor;
 		editor.getSession().clearAnnotations();
-		this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::resetAnnotations();
+		this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::resetAnnotations()();
 	}-*/;
 
 	/**


### PR DESCRIPTION
Fixed the clearAnnotations() JS native method so that it calls the resetAnnotations() method correctly.

I committed the same basic change to the part of the code that's in the CloudCoder GWT project.
