### PR TITLE
Added field Element divElement to class AceEditor.  Changed startEditor(...

### DIFF
--- a/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
+++ b/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
@@ -23,6 +23,7 @@ package edu.ycp.cs.dh.acegwt.client.ace;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.TakesValue;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasText;
@@ -33,7 +34,7 @@ import com.google.gwt.user.client.ui.RequiresResize;
  *
  * @see <a href="http://ace.ajax.org/">Ajax.org Code Editor</a>
  */
-public class AceEditor extends Composite implements RequiresResize, HasText {
+public class AceEditor extends Composite implements RequiresResize, HasText, TakesValue<String> {
 	// Used to generate unique element ids for Ace widgets.
 	private static int nextId = 0;
 
@@ -375,5 +376,15 @@ public class AceEditor extends Composite implements RequiresResize, HasText {
 	@Override
 	public void onResize() {
 		redisplay();
+	}
+
+	@Override
+	public void setValue(String value) {
+		this.setText(value);
+	}
+
+	@Override
+	public String getValue() {
+		return this.getText();
 	}
 }


### PR DESCRIPTION
A few changes:
1. `AceEditor` implements 2 interfaces used by  `com.google.gwt.user.client.ui.TextBox`.
   - `com.google.gwt.user.client.ui.HasText`
   - `com.google.gwt.user.client.TakesValue<String>`
2. I've changed the `startEditor()` method to use to a local copy of the div `Element` containing the editor javascript object.  If the DOM tree is large, there is a considerable performance improvement. 
