### PR TITLE
Add ace namespace to $wnd.require

### DIFF
--- a/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
+++ b/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
@@ -160,7 +160,7 @@ public class AceEditor extends Composite implements RequiresResize, HasText, Tak
 	public native void setModeByName(String shortModeName) /*-{
 		var editor = this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::editor;
 		var modeName = "ace/mode/" + shortModeName;
-		var TheMode = $wnd.require(modeName).Mode;
+		var TheMode = $wnd.ace.require(modeName).Mode;
 		editor.getSession().setMode(new TheMode());
 	}-*/;
 


### PR DESCRIPTION
I was wondering if this might be the reason you specify that you MUST add the ace.js file to the html page. In using your module (thank you, by the way). I found that all the other calls to $wnd.require were using the ace namespace. In my use of this module I override setModeByName in a custom subclass of AceEditor and I have found that adding the ace namespace allows me to load ace.js with ScriptInjector.fromUrl(String) without having to explicitly add ace.js to my html page.