### PR TITLE
Fix bad `setFontSize(String...)`

### DIFF
--- a/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
+++ b/AceGWT/src/edu/ycp/cs/dh/acegwt/client/ace/AceEditor.java
@@ -214,9 +214,8 @@ public class AceEditor extends Composite implements RequiresResize, HasText, Tak
 	 * @param fontSize the font size to set, e.g., "16px"
 	 */
 	public native void setFontSize(String fontSize) /*-{
-		var elementId = this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::elementId;
-		var elt = $doc.getElementById(elementId);
-		elt.style.fontSize = fontSize;
+		var editor = this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::editor;
+		editor.setFontSize(fontSize);
 	}-*/;
 
 	/**
@@ -225,7 +224,7 @@ public class AceEditor extends Composite implements RequiresResize, HasText, Tak
 	 */
 	public native void setFontSize(int fontSize) /*-{
 		var editor = this.@edu.ycp.cs.dh.acegwt.client.ace.AceEditor::editor;
-		return editor.setFontSize(fontSize);
+		editor.setFontSize(fontSize);
 	}-*/;
 
 	/**


### PR DESCRIPTION
Currently, the use of `setFontSize(String)` results in:

    > Cannot read property 'style' of null

This commit uses the same code as `setFontSize(Integer)` and removes the `return` at the end of `setFontSize(Integer)` so it matches the return parameter.