### PR TITLE
Updated GWT version to 2.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -4,7 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>edu.ycp.cs.dh</groupId>
+    <parent>
+        <groupId>edu.ycp.cs.dh</groupId>
+        <artifactId>acegwt-2.11.0</artifactId>
+        <version>1.3.3</version>
+    </parent>
+
     <artifactId>acegwt</artifactId>
     <version>1.3.3</version>
     <packaging>gwt-lib</packaging>

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -25,7 +25,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependencies -->
-        <gwt.version>2.8.2</gwt.version>
+        <gwt.version>2.11.0</gwt.version>
 
         <!-- plugins -->
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
@@ -66,7 +66,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.gwt</groupId>
+                <groupId>org.gwtproject</groupId>
                 <artifactId>gwt</artifactId>
                 <version>${gwt.version}</version>
                 <type>pom</type>
@@ -77,20 +77,20 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-codeserver</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-servlet</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -51,8 +51,8 @@
         <github.global.server>github</github.global.server>
 
         <!-- AceGWT repository -->
-        <acegwt.repository.name>AceGWT</acegwt.repository.name>
-        <acegwt.repository.owner>josepaiva94</acegwt.repository.owner>
+        <acegwt.repository.name>AceGWT-2.11.0</acegwt.repository.name>
+        <acegwt.repository.owner>simdeistud</acegwt.repository.owner>
     </properties>
 
     <distributionManagement>

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -33,7 +33,7 @@
         <gwt.version>2.11.0</gwt.version>
 
         <!-- plugins -->
-        <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <gwt-maven-plugin.version>1.0-rc-9</gwt-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -30,7 +30,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependencies -->
-        <gwt.version>2.11.0</gwt.version>
+        <gwt.version>2.13.0</gwt.version>
 
         <!-- plugins -->
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -34,7 +34,7 @@
 
         <!-- plugins -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <gwt-maven-plugin.version>1.0-rc-9</gwt-maven-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <site-maven-plugin.version>0.12</site-maven-plugin.version>

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -35,7 +35,7 @@
         <!-- plugins -->
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-        <gwt-maven-plugin.version>1.0-rc-9</gwt-maven-plugin.version>
+        <gwt-maven-plugin.version>1.2.0</gwt-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <site-maven-plugin.version>0.12</site-maven-plugin.version>
 

--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -36,7 +36,7 @@
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <gwt-maven-plugin.version>1.0-rc-9</gwt-maven-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <site-maven-plugin.version>0.12</site-maven-plugin.version>
 
         <!-- directory for webapp -->

--- a/AceGWT/src/main/module.gwt.xml
+++ b/AceGWT/src/main/module.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN"
-        "http://gwtproject.org/doctype/2.8.2/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN"
+        "http://gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module rename-to="acegwt">
   <inherits name='com.google.gwt.user.User'/>
 

--- a/AceGWTDemo/pom.xml
+++ b/AceGWTDemo/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependencies -->
-        <gwt.version>2.8.2</gwt.version>
+        <gwt.version>2.11.0</gwt.version>
         <acegwt.version>1.3.3</acegwt.version>
 
         <!-- plugins -->
@@ -51,7 +51,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.gwt</groupId>
+                <groupId>org.gwtproject</groupId>
                 <artifactId>gwt</artifactId>
                 <version>${gwt.version}</version>
                 <type>pom</type>
@@ -62,20 +62,20 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-codeserver</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-servlet</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/AceGWTDemo/pom.xml
+++ b/AceGWTDemo/pom.xml
@@ -4,7 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>edu.ycp.cs.dh</groupId>
+    <parent>
+        <groupId>edu.ycp.cs.dh</groupId>
+        <artifactId>acegwt-2.11.0</artifactId>
+        <version>1.3.3</version>
+    </parent>
+
     <artifactId>acegwt-demo</artifactId>
     <version>0.0.1</version>
     <packaging>gwt-app</packaging>
@@ -40,7 +45,8 @@
     <repositories>
         <repository>
             <id>acegwt-${acegwt.version}</id>
-            <url>https://raw.github.com/${acegwt.repository.owner}/${acegwt.repository.name}/acegwt-${acegwt.version}</url>
+            <url>https://raw.github.com/${acegwt.repository.owner}/${acegwt.repository.name}/acegwt-${acegwt.version}
+            </url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
@@ -164,5 +170,5 @@
             </plugin>
         </plugins>
     </build>
-    
+
 </project>

--- a/AceGWTDemo/src/main/module.gwt.xml
+++ b/AceGWTDemo/src/main/module.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN"
-        "http://gwtproject.org/doctype/2.8.2/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN"
+        "http://gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module rename-to="acegwtdemo">
     <inherits name='com.google.gwt.user.User'/>
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The [wiki](https://github.com/daveho/AceGWT/wiki) has more information, includin
 
 Also, there is [javadoc](http://daveho.github.io/AceGWT/api/).
 
+## What is included in this forked version
+
+This version has been updated to use GWT 2.11.0 which has switced to using a different Maven repository.
+
+To include this library in your project you need to set up this GitHub repository as a maven repo in your pom.xml file by doing as follows:
+
 ## Latest news
 
 15 June 2018

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>edu.ycp.cs.dh</groupId>
+    <artifactId>acegwt-2.11.0</artifactId>
+    <version>1.3.3</version>
+    <packaging>pom</packaging>
+    <name>AceGWT-2.11.0</name>
+    <description>
+        Ace is an embeddable code editor written in JavaScript. It matches the features and performance of native
+        editors such as Sublime, Vim and TextMate. It can be easily embedded in any web page and JavaScript application.
+        Ace is maintained as the primary editor for Cloud9 IDE and is the successor of the Mozilla Skywriter (Bespin)
+        project.
+        AceGWT is an integration of Ace into GWT.
+    </description>
+
+    <modules>
+        <module>AceGWT</module>
+        <!-- <module>AceGWTDemo</module> -->
+    </modules>
+
+</project>


### PR DESCRIPTION
More recent versions of GWT use a different Maven repository. The pom.xml files and .gwt.xml files have been updated accordingly.